### PR TITLE
always restart containers

### DIFF
--- a/catchemall/docker-compose.deploy.yml
+++ b/catchemall/docker-compose.deploy.yml
@@ -12,7 +12,6 @@ services:
       restart_policy:
         condition: any
         delay: 3s
-        max_attempts: 3
       update_config:
         monitor: 5s
         failure_action: rollback
@@ -34,7 +33,6 @@ services:
       restart_policy:
         condition: any
         delay: 3s
-        max_attempts: 3
       update_config:
         monitor: 5s
         failure_action: rollback


### PR DESCRIPTION
When a container crashed on the deployed machine it was not attempting to restart after 3 attempts.

Solution - always try to restart.