### PR TITLE
fix(migrations) - cascade delete trades on user remove

### DIFF
--- a/catchemall/web-api/src/db/migrations/4_pokemon_trade_cascade_delete.sql
+++ b/catchemall/web-api/src/db/migrations/4_pokemon_trade_cascade_delete.sql
@@ -1,0 +1,8 @@
+ALTER TABLE pokemon_trade
+DROP CONSTRAINT fk_initiator_user_pokemon_id;
+
+ALTER TABLE pokemon_trade
+DROP CONSTRAINT fk_responder_user_pokemon_id;
+
+ALTER TABLE pokemon_trade ADD CONSTRAINT fk_initiator_user_pokemon_id FOREIGN KEY (initiator_user_pokemon_id) REFERENCES "user_pokemon" (id) ON DELETE CASCADE;
+ALTER TABLE pokemon_trade ADD CONSTRAINT fk_responder_user_pokemon_id FOREIGN KEY (responder_user_pokemon_id) REFERENCES "user_pokemon" (id) ON DELETE CASCADE;


### PR DESCRIPTION
If a user is deleted, their trades should be removed as well.